### PR TITLE
Updated to latest rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(plugin_registrar, quote)]
 #![deny(missing_docs, warnings)]
 
+#![allow(unstable)]
+
 //! Stainless is a lightweight, flexible, unopinionated testing framework.
 //!
 //! ## Example
@@ -95,7 +97,7 @@ mod generate;
 #[plugin_registrar]
 #[doc(hidden)]
 pub fn plugin_registrar(reg: &mut plugin::Registry) {
-    reg.register_syntax_extension(token::intern("describe"), syntax::ext::base::IdentTT(box describe, None));
+    reg.register_syntax_extension(token::intern("describe"), syntax::ext::base::IdentTT(Box::new(describe), None));
 }
 
 


### PR DESCRIPTION
This adds the `allow(unstable)` attribute, which is not ideal, however I think it's needed for now, seeing as the `rustc` and `syntax` crates which are used here are both marked as unstable.