### PR TITLE
(fix) Remove unnecessary `extern crate stainless`.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,6 @@
 #![feature(plugin, test)]
 #![plugin(stainless)]
 
-extern crate stainless;
 extern crate test;
 
 describe! benchmarking {

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 describe! failing {
     failing "should fail" {
         panic!("should still pass");

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 #[cfg(test)]
 mod test {
     pub fn test_helper<T: PartialEq>(x: T, y: T) {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 describe! top_level {
     it "should be less specific" {
         assert_eq!(1, 1);

--- a/tests/nested_hooks.rs
+++ b/tests/nested_hooks.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 describe! top_level {
     before_each {
         let mut foo = 1;

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 describe! addition {
     before_each {
         let x = 5;

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,8 +1,6 @@
 #![feature(plugin)]
 #![plugin(stainless)]
 
-extern crate stainless;
-
 #[derive(Copy)]
 pub struct X(i32);
 


### PR DESCRIPTION
Removes warnings for latest Rust.