### PR TITLE
Updates for rustc nightly c89de2c56

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ describe! stainless {
     }
 
     bench "something simple" (bencher) {
-        bencher.iter(|| 2u * 2)
+        bencher.iter(|| 2 * 2)
     }
 
     describe! nesting {
         it "makes it simple to categorize tests" {
             // It even generates submodules!
-            assert_eq!(2u, 2u);
+            assert_eq!(2, 2);
         }
     }
 }
@@ -47,13 +47,13 @@ mod stainless {
 
     #[bench]
     fn something_simple(bencher: &mut test::Bencher) {
-        bencher.iter(|| 2u * 2)
+        bencher.iter(|| 2 * 2)
     }
 
     mod nesting {
         #[test]
         fn makes_it_simple_to_categorize_tests() {
-            assert_eq!(2u, 2u);
+            assert_eq!(2, 2);
         }
     }
 }
@@ -76,7 +76,7 @@ and teardown for a group of tests into a single block, shortening your
 tests.
 
 `it` generates tests which use `before_each` and `after_each`. `failing`
-does the same, except the generated tests are marked with `#[should_fail]`.
+does the same, except the generated tests are marked with `#[should_panic]`.
 
 `bench` allows you to generate benchmarks in the same fashion, though
 `before_each` and `after_each` blocks do not affect `bench` blocks.

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -25,8 +25,8 @@ impl<'a> Generate<&'a DescribeState> for Test {
         // Create the #[test] attribute.
         let test_attribute = cx.attribute(sp, cx.meta_word(sp, token::InternedString::new("test")));
 
-        // Create the #[should_fail] attribute.
-        let should_fail = cx.attribute(sp, cx.meta_word(sp, token::InternedString::new("should_fail")));
+        // Create the #[should_panic] attribute.
+        let should_panic = cx.attribute(sp, cx.meta_word(sp, token::InternedString::new("should_panic")));
 
         let non_snake_word = cx.meta_word(sp, token::InternedString::new("non_snake_case"));
         let allow_non_snake_case = cx.meta_list(sp, token::InternedString::new("allow"),
@@ -63,16 +63,16 @@ impl<'a> Generate<&'a DescribeState> for Test {
         // Constructing attributes:
         // #[test] - no way without it
         // #[allow(non_snake_case_attr)] as description may contain upper case
-        // #[should_fail] if specified
+        // #[should_panic] if specified
         let mut attrs = vec![test_attribute, allow_non_snake_case];
         if failing {
-            attrs.push(should_fail);
+            attrs.push(should_panic);
         }
 
         // Create the final Item that represents the test.
         P(ast::Item {
             // Name it with a snake_case version of the description.
-            ident: cx.ident_of(description.replace(" ", "_").as_slice()),
+            ident: cx.ident_of(&description.replace(" ", "_")),
             attrs: attrs,
             id: ast::DUMMY_NODE_ID,
             node: ast::ItemFn(
@@ -107,9 +107,9 @@ impl Generate<()> for Bench {
         // Create the final Item that represents the benchmark.
         P(ast::Item {
             // Name it with a snake_case version of the description.
-            ident: cx.ident_of(description.replace(" ", "_").as_slice()),
+            ident: cx.ident_of(&description.replace(" ", "_")),
 
-            // Add #[test] and possibly #[should_fail]
+            // Add #[test] and possibly #[should_panic]
             attrs: vec![bench_attribute],
             id: ast::DUMMY_NODE_ID,
             node: ast::ItemFn(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, rustc_private, core)]
+#![feature(plugin_registrar, quote, rustc_private)]
 #![deny(missing_docs, warnings)]
 
 //! Stainless is a lightweight, flexible, unopinionated testing framework.
@@ -25,7 +25,7 @@
 //!     describe! nesting {
 //!         it "makes it simple to categorize tests" {
 //!             // It even generates submodules!
-//!             assert_eq!(2u, 2u);
+//!             assert_eq!(2, 2);
 //!         }
 //!     }
 //! }
@@ -45,7 +45,7 @@
 //!     mod nesting {
 //!         #[test]
 //!         fn makes_it_simple_to_categorize_tests() {
-//!             assert_eq!(2u, 2u);
+//!             assert_eq!(2, 2);
 //!         }
 //!     }
 //! }
@@ -66,7 +66,7 @@
 //! tests.
 //!
 //! `it` generates tests which use `before_each` and `after_each`. `failing`
-//! does the same, except the generated tests are marked with `#[should_fail]`.
+//! does the same, except the generated tests are marked with `#[should_panic]`.
 //!
 //! `bench` allows you to generate benchmarks in the same fashion, though
 //! `before_each` and `after_each` blocks do not affect `bench` blocks.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,7 +41,7 @@ impl Parse<()> for Bench {
             (token::OpenDelim(token::Paren), ident, token::CloseDelim(token::Paren)) => { ident },
 
             (one, two, three) => {
-                parser.fatal(format!("Expected `($ident)`, found {:?}{:?}{:?}", one, two, three).as_slice())
+                parser.fatal(&format!("Expected `($ident)`, found {:?}{:?}{:?}", one, two, three))
             }
         };
 
@@ -122,7 +122,7 @@ impl<'a, 'b> Parse<(codemap::Span, &'a mut base::ExtCtxt<'b>, Option<ast::Ident>
                 // Regular `#[test]`.
                 IT => { state.subblocks.push(SubBlock::Test(Parse::parse(parser, false))) },
 
-                // `#[should_fail]` test.
+                // `#[should_panic]` test.
                 FAILING => { state.subblocks.push(SubBlock::Test(Parse::parse(parser, true))) },
 
                 // #[bench] benchmark.
@@ -153,17 +153,17 @@ impl<'a, 'b> Parse<(codemap::Span, &'a mut base::ExtCtxt<'b>, Option<ast::Ident>
 fn try(parser: &mut Parser, token: token::Token, err: &str) {
     let real = parser.bump_and_get();
     if real != token {
-        parser.fatal(format!("Expected {}, but found `{:?}`", err, real).as_slice())
+        parser.fatal(&format!("Expected {}, but found `{:?}`", err, real))
     }
 }
 
 fn illegal(parser: &mut Parser, banned: &str) {
     // Illegal block name.
     let span = parser.span;
-    parser.span_fatal(span, format!("Expected one of: `{}`, but found: `{}`",
+    parser.span_fatal(span, &format!("Expected one of: `{}`, but found: `{}`",
         format!("{}, {}, {}, {}, {}, {}, {}, {}",
                 BEFORE_EACH, AFTER_EACH, BEFORE, AFTER,
-                IT, BENCH, FAILING, DESCRIBE).as_slice(),
-        banned).as_slice());
+                IT, BENCH, FAILING, DESCRIBE),
+        banned));
 }
 


### PR DESCRIPTION
A couple changes to update stainless to the rustc nightly as of 3/29/2015:
- Remove unused `core`
- replace deprecated `as_slice` with deref coercions
- `should_fail` -> `should_panic`
- remove unneeded `u` suffix