### PR TITLE
Fix for nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,5 +100,3 @@ pub fn plugin_registrar(reg: &mut plugin::Registry) {
         syntax::ext::base::IdentTT(Box::new(describe), None, false)
     );
 }
-
-

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -99,9 +99,9 @@ impl<'a, 'b> Parse<(codemap::Span, &'a mut base::ExtCtxt<'b>, Option<ast::Ident>
             //     - describe!
             //
             // Any other top-level idents are not allowed.
-            let block_name = parser.parse_ident().ok().unwrap();
+            let block_name = parser.parse_ident().ok().unwrap().name;
 
-            match block_name.as_str() {
+            match &*block_name.as_str() {
                 BEFORE_EACH | GIVEN => {
                     if state.before_each.is_some() {
                         panic!("{}", parser.fatal("Only one `before_each` block is allowed per `describe!` block."));
@@ -177,4 +177,3 @@ fn illegal(parser: &mut Parser, banned: &str) {
                 IT, BENCH, FAILING, DESCRIBE),
         banned)));
 }
-


### PR DESCRIPTION
This change makes it compile with the latest nightly again. The internals have changed a bit. And `Ident` how contains a `Name`. Unfortunately calling `as_str()` on `Name` returns an `InternedString`. Hence the hack with `format!`.