### PR TITLE
Stainless not working on nightly

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,7 +41,7 @@ impl Parse<()> for Bench {
             (token::OpenDelim(token::Paren), ident, token::CloseDelim(token::Paren)) => { ident },
 
             (one, two, three) => {
-                panic!("{}", parser.fatal(&format!("Expected `($ident)`, found {:?}{:?}{:?}", one, two, three)));
+                panic!("{:?}", parser.fatal(&format!("Expected `($ident)`, found {:?}{:?}{:?}", one, two, three)));
             }
         };
 
@@ -104,28 +104,28 @@ impl<'a, 'b> Parse<(codemap::Span, &'a mut base::ExtCtxt<'b>, Option<ast::Ident>
             match &*block_name.as_str() {
                 BEFORE_EACH | GIVEN => {
                     if state.before_each.is_some() {
-                        panic!("{}", parser.fatal("Only one `before_each` block is allowed per `describe!` block."));
+                        panic!("{:?}", parser.fatal("Only one `before_each` block is allowed per `describe!` block."));
                     }
                     state.before_each = Some(parser.parse_block().ok().unwrap());
                 },
 
                 AFTER_EACH | THEN => {
                     if state.after_each.is_some() {
-                        panic!("{}", parser.fatal("Only one `after_each` block is allowed per `describe!` block."));
+                        panic!("{:?}", parser.fatal("Only one `after_each` block is allowed per `describe!` block."));
                     }
                     state.after_each = Some(parser.parse_block().ok().unwrap());
                 },
 
                 BEFORE => {
                     if state.before.is_some() {
-                        panic!("{}", parser.fatal("Only one `before` block is allowed per `describe!` block."));
+                        panic!("{:?}", parser.fatal("Only one `before` block is allowed per `describe!` block."));
                     }
                     state.before = Some(parser.parse_block().ok().unwrap());
                 },
 
                 AFTER => {
                     if state.after.is_some() {
-                        panic!("{}", parser.fatal("Only one `after` block is allowed per `describe!` block."));
+                        panic!("{:?}", parser.fatal("Only one `after` block is allowed per `describe!` block."));
                     }
                     state.after = Some(parser.parse_block().ok().unwrap());
                 },
@@ -164,14 +164,14 @@ impl<'a, 'b> Parse<(codemap::Span, &'a mut base::ExtCtxt<'b>, Option<ast::Ident>
 fn try(parser: &mut Parser, token: token::Token, err: &str) {
     let real = parser.bump_and_get().ok().unwrap();
     if real != token {
-        panic!("{}", parser.fatal(&format!("Expected {}, but found `{:?}`", err, real)));
+        panic!("{:?}", parser.fatal(&format!("Expected {}, but found `{:?}`", err, real)));
     }
 }
 
 fn illegal(parser: &mut Parser, banned: &str) {
     // Illegal block name.
     let span = parser.span;
-    panic!("{}", parser.span_fatal(span, &format!("Expected one of: `{}`, but found: `{}`",
+    panic!("{:?}", parser.span_fatal(span, &format!("Expected one of: `{}`, but found: `{}`",
         format!("{}, {}, {}, {}, {}, {}, {}, {}",
                 BEFORE_EACH, AFTER_EACH, BEFORE, AFTER,
                 IT, BENCH, FAILING, DESCRIBE),


### PR DESCRIPTION
Hi,

I'm new to rust and was trying to use stainless for the first time and it doesn't appear to be working on nightly.

I forked stainless and couldn't run the test getting a whole bunch of errors like this:

```
cargo test
   Compiling stainless v0.1.2 (file:///code)
src/parse.rs:44:30: 44:112 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:44                 panic!("{}", parser.fatal(&format!("Expected `($ident)`, found {:?}{:?}{:?}", one, two, three)));
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:44:17: 44:114 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:44:30: 44:112 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:44:30: 44:112 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:44:30: 44:112 note: required by `core::fmt::Display::fmt`
src/parse.rs:107:38: 107:116 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:107                         panic!("{}", parser.fatal("Only one `before_each` block is allowed per `describe!` block."));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:107:25: 107:118 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:107:38: 107:116 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:107:38: 107:116 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:107:38: 107:116 note: required by `core::fmt::Display::fmt`
src/parse.rs:114:38: 114:115 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:114                         panic!("{}", parser.fatal("Only one `after_each` block is allowed per `describe!` block."));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:114:25: 114:117 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:114:38: 114:115 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:114:38: 114:115 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:114:38: 114:115 note: required by `core::fmt::Display::fmt`
src/parse.rs:121:38: 121:111 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:121                         panic!("{}", parser.fatal("Only one `before` block is allowed per `describe!` block."));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:121:25: 121:113 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:121:38: 121:111 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:121:38: 121:111 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:121:38: 121:111 note: required by `core::fmt::Display::fmt`
src/parse.rs:128:38: 128:110 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:128                         panic!("{}", parser.fatal("Only one `after` block is allowed per `describe!` block."));
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:128:25: 128:112 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:128:38: 128:110 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:128:38: 128:110 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:128:38: 128:110 note: required by `core::fmt::Display::fmt`
src/parse.rs:167:22: 167:88 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:167         panic!("{}", parser.fatal(&format!("Expected {}, but found `{:?}`", err, real)));
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:167:9: 167:90 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:167:22: 167:88 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:167:22: 167:88 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:167:22: 167:88 note: required by `core::fmt::Display::fmt`
src/parse.rs:174:18: 178:17 error: the trait `core::fmt::Display` is not implemented for the type `syntax::errors::DiagnosticBuilder<'_>` [E0277]
src/parse.rs:174     panic!("{}", parser.span_fatal(span, &format!("Expected one of: `{}`, but found: `{}`",
src/parse.rs:175         format!("{}, {}, {}, {}, {}, {}, {}, {}",
src/parse.rs:176                 BEFORE_EACH, AFTER_EACH, BEFORE, AFTER,
src/parse.rs:177                 IT, BENCH, FAILING, DESCRIBE),
src/parse.rs:178         banned)));
<std macros>:9:1: 9:40 note: in this expansion of format_args!
src/parse.rs:174:5: 178:19 note: in this expansion of panic! (defined in <std macros>)
src/parse.rs:174:18: 178:17 help: run `rustc --explain E0277` to see a detailed explanation
src/parse.rs:174:18: 178:17 note: `syntax::errors::DiagnosticBuilder<'_>` cannot be formatted with the default formatter; try using `:?` instead if you are using a format string
src/parse.rs:174:18: 178:17 note: required by `core::fmt::Display::fmt`
error: aborting due to 7 previous errors
Could not compile `stainless`.

To learn more, run the command again with --verbose.
```

This PR get's those test to pass but only via using fmt::Debug instead.

I'm guessing this is not the preferred solution but thought I'd raise a PR to highlight the issue.