### PR TITLE
Run benchmarks on Travis as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: rust
 rust: nightly
+script:
+  - cargo build
+  - cargo test
+  - cargo bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
 rust: nightly
+cache: cargo
+os:
+  - linux
+  - osx
 script:
   - cargo build
   - cargo test

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, test)]
+#![feature(plugin,const_fn,test)]
 #![plugin(stainless)]
 
 extern crate test;
@@ -8,4 +8,3 @@ describe! benchmarking {
             bencher.iter(|| 2 * 2)
     }
 }
-

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn,test)]
+#![feature(plugin, test)]
 #![plugin(stainless)]
 
 extern crate test;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -150,7 +150,7 @@ impl Generate<()> for Bench {
 
                 // All the usual types.
                 ast::Unsafety::Normal,
-                ast::Constness::Const,
+                ast::Constness::NotConst,
                 abi::Abi::Rust,
                 ast::Generics::default(),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, rustc_private,const_fn)]
+#![feature(plugin_registrar, quote, rustc_private)]
 #![deny(missing_docs, warnings)]
 
 //! Stainless is a lightweight, flexible, unopinionated testing framework.

--- a/tests/alternates.rs
+++ b/tests/alternates.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! top_level {

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! failing {

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 #[cfg(test)]
@@ -13,4 +13,3 @@ mod test {
         }
     }
 }
-

--- a/tests/ignore.rs
+++ b/tests/ignore.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! ignored_tests {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! top_level {

--- a/tests/nested_hooks.rs
+++ b/tests/nested_hooks.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! top_level {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 describe! addition {
@@ -16,4 +16,3 @@ describe! addition {
         assert_eq!(y, 6);
     }
 }
-

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,4 +1,4 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
The default Travis configuration for Rust only runs `cargo build` and `cargo test`. But we also need to run `cargo bench`. Of course this pull request won't pass as #40 isn't merge yet. But even after that it will break the build as the benchmarking is actually broken. But hey, at least we know now. :)