### PR TITLE
Improved the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,64 @@
 
 > Stainless is a lightweight, flexible, unopinionated testing framework.
 
+**Note that stainless currently requires the nightly version of the Rust compiler!**
+
+## Installation
+
+Add stainless as a dependency in your `Cargo.toml` file
+``` toml
+[dev-dependencies]
+stainless = "*"
+```
+
+Add the following lines to the top of your
+[root module](https://doc.rust-lang.org/book/crates-and-modules.html).
+That file is normally called `src/main.rs` for executables and
+`src/lib.rs` for libraries:
+
+``` rust
+#![feature(plugin)]
+#![cfg_attr(test, plugin(stainless))]
+```
+
+This will make stainless available when you run the tests using `cargo
+test`.
+
+## Overview
+
+Stainless exports the `describe!` syntax extension, which allows you
+to quickly generate complex testing hierarchies and reduce boilerplate
+through `before_each` and `after_each`.
+
+Stainless currently supports 4 types of subblocks:
+ - `before_each` and `after_each`,
+ - `it` and `failing`
+ - `bench`
+ - nested `describe!`
+
+`before_each` and `after_each` allow you to group common
+initialization and teardown for a group of tests into a single block,
+shortening your tests.
+
+`it` generates tests which use `before_each` and `after_each`.
+`failing` does the same, except the generated tests are marked with
+`#[should_panic]`.
+
+`bench` allows you to generate benchmarks in the same fashion, though
+*`before_each` and `after_each` blocks do not currently affect `bench`
+blocks*.
+
+Nested `describe!` blocks allow you to better organize your tests into
+small units and gives you granular control over where `before_each`
+and `after_each` apply. Of course the `before_each` and `after_each`
+blocks of the wrapping `describe!` blocks are executed as well.
+
+Together, these 4 types of subblocks give you more flexibility and
+control than the built in testing infrastructure.
+
 ## Example
 
-```ignore
+```rust
 describe! stainless {
     before_each {
         // Start up a test.
@@ -26,6 +81,15 @@ describe! stainless {
     }
 
     describe! nesting {
+
+        before_each {
+          let mut inner_stainless = true;
+        }
+
+        after_each {
+          inner_stainless = false;
+        }
+
         it "makes it simple to categorize tests" {
             // It even generates submodules!
             assert_eq!(2, 2);
@@ -53,49 +117,29 @@ mod stainless {
     mod nesting {
         #[test]
         fn makes_it_simple_to_categorize_tests() {
+            let mut stainless = true;
+            let mut inner_stainless = true;
             assert_eq!(2, 2);
+            inner_stainless = false;
+            stainless = false;
         }
     }
 }
 ```
 
-## Overview
+## Importing modules
 
-Stainless exports the `describe!` syntax extension, which allows
-you to quickly generate complex testing hierarchies and reduce
-boilerplate through `before_each` and `after_each`.
-
-Stainless currently supports 4 types of subblocks:
- - `before_each` and `after_each`,
- - `it` and `failing`
- - `bench`
- - nested `describe!`
-
-`before_each` and `after_each` allow you to group common initialization
-and teardown for a group of tests into a single block, shortening your
-tests.
-
-`it` generates tests which use `before_each` and `after_each`. `failing`
-does the same, except the generated tests are marked with `#[should_panic]`.
-
-`bench` allows you to generate benchmarks in the same fashion, though
-`before_each` and `after_each` blocks do not affect `bench` blocks.
-
-Nested `describe!` blocks allow you to better organize your tests into
-small units and gives you granular control over where `before_each` and
-`after_each` apply.
-
-Together, these 4 types of subblocks give you more flexibility and control
-than the built in testing infrastructure.
-
-Each describe block comes with a silent pub use super::*; in it, so you can
-`pub use` in the containing module if you want to import modules for your tests:
+At this point it is not possible to put `use` statements inside the
+`describe!` blocks. To allow usage of data structures from other
+modules and crates each `describe!` block comes with a silent `pub use
+super::*;` in it. That way everything you `pub use` in the containing
+module is available in your tests.
 
 ```rust
 #[cfg(test)]
 mod tests {
     pub use std::collections::HashMap;
-    
+
     describe! stainless {
         it "can use HashMap" {
             let map = HashMap::new();
@@ -107,4 +151,3 @@ mod tests {
 ## License
 
 MIT
-


### PR DESCRIPTION
Recently a few people (e.g. @grosser & @xetra11) had issues with stainless mainly due to the lack of documentation. I've tried to clarify the README a bit. [See here for how Github would render it](https://github.com/ujh/stainless/tree/improve-readme).

* Added note about the fact that the nightly compiler build is required
* Added instructions on how to integrate stainless
* Reordered sections (overview before the example)
* Added `before_each` & `after_each` to the nested `describe!` in the example
* Clarified the `pub use` requirement