### PR TITLE
Suppressed the result of expressions at the end of test blocks

### DIFF
--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,0 +1,24 @@
+#![feature(plugin,const_fn)]
+#![plugin(stainless)]
+
+describe! addition {
+    before_each {
+        let x = 5;
+        let y = 6;
+        for _ in 0..5 {
+        }
+    }
+
+    it "should add 5 and 6 together" {
+        assert_eq!(x + y, 11);
+        for _ in 0..5 {
+        }
+    }
+
+    after_each {
+        assert_eq!(x, 5);
+        assert_eq!(y, 6);
+        for _ in 0..5 {
+        }
+    }
+}

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,24 +1,30 @@
-#![feature(plugin,const_fn)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
-describe! addition {
+describe! expression_at_end_of_block {
     before_each {
         let x = 5;
         let y = 6;
+        let mut z = 0;
         for _ in 0..5 {
+            z += 1;
         }
     }
 
-    it "should add 5 and 6 together" {
+    it "should execute expressions at ends of test blocks as statements" {
         assert_eq!(x + y, 11);
+        assert_eq!(z, 5);
         for _ in 0..5 {
+            z += 1;
         }
     }
 
     after_each {
         assert_eq!(x, 5);
         assert_eq!(y, 6);
+        assert_eq!(z, 10);
         for _ in 0..5 {
+            // Purposefully empty-- tests that after_each can end with loop
         }
     }
 }


### PR DESCRIPTION
Fix #34, #47 

Converted the optional expr at the end of test blocks to a statement so that test blocks can end with an unsuppressed expression (including loop statements).

A bit of a mess (lots of cloning) because of ownership issues. Suggestions are welcome.