### PR TITLE
Add MIT license and license headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,19 @@
 
 name = "stainless"
 version = "0.1.5"
-authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
+authors = [
+  "Jonathan Reem <jonathan.reem@gmail.com>",
+  "Aleksey Kuznetsov <zummenix@gmail.com>",
+  "Alex Diez <alexvic.amatory@gmail.com>",
+  "Mark Schifflin <rschifflin@hotmail.com>",
+  "Seb Glazebrook <sebastian.glazebrook@redbubble.com>",
+  "Taylor Cramer <cramertj@cs.washington.edu>",
+  "Thijs Cadier <thijs@appsignal.com>",
+  "Urban Hafner <contact@urbanhafner.com>",
+  "Utkarsh Kukreti <utkarshkukreti@gmail.com>",
+  "Valerii Hiora <valerii.hiora@gmail.com>",
+  "Vladimir Pouzanov <farcaller@gmail.com>",
+]
 description = "Organized, flexible testing framework."
 repository = "https://github.com/reem/stainless"
 license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,8 @@ mod tests {
 
 ## License
 
-MIT
+MIT. See the LICENSE file for details.
+
+## Authors
+
+See Cargo.toml for the full list of authors.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin, test)]
 #![plugin(stainless)]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin, test)]
 #![plugin(stainless)]
 

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,3 +1,21 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Utkarsh Kukreti
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 use syntax::ast;
 use syntax::ptr::P;
 
@@ -9,4 +27,3 @@ pub struct Bench {
     pub description: String,
     pub block: P<ast::Block>
 }
-

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,5 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Utkarsh Kukreti
+// Copyright 2014-2015 The Stainless Developers.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2015 The Stainless Developers.
+// Copyright 2014-2015 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 use syntax::ast;
 use syntax::ptr::P;

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1,5 +1,4 @@
-// Copyright 2014 Jonathan Reem, Utkarsh Kukreti
-// Copyright 2015 Utkarsh Kukreti
+// Copyright 2014-2015 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2015 The Stainless Developers
+// Copyright 2014-2015 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 /// ## Internal Code Guide
 ///

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1,3 +1,21 @@
+// Copyright 2014 Jonathan Reem, Utkarsh Kukreti
+// Copyright 2015 Utkarsh Kukreti
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 /// ## Internal Code Guide
 ///
 /// This crate is centered around two traits, Parse and Generate,
@@ -64,4 +82,3 @@ pub fn describe<'a>(cx: &'a mut base::ExtCtxt, sp: codemap::Span,
     // Export the new module.
     base::MacEager::items(SmallVector::one(state.generate(sp, cx, None)))
 }
-

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem, Utkarsh Kukreti, Valerii Hiora
+// Copyright 2015 Jonathan Reem, Urban Hafner, Mark Schifflin, Utkarsh Kukreti
+// Copyright 2016 Taylor Cramer, Urban Hafner, Alex Diez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 use std::ops::Deref;
 
 use syntax::{ast, abi, codemap};

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem, Utkarsh Kukreti, Valerii Hiora
-// Copyright 2015 Jonathan Reem, Urban Hafner, Mark Schifflin, Utkarsh Kukreti
-// Copyright 2016 Taylor Cramer, Urban Hafner, Alex Diez
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 use std::ops::Deref;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin_registrar, quote, rustc_private)]
 #![deny(missing_docs, warnings)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,23 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Utkarsh Kukreti, Mark Schifflin,
+//                Aleksey Kuznetsov
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin_registrar, quote, rustc_private)]
 #![deny(missing_docs, warnings)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Utkarsh Kukreti, Mark Schifflin,
-//                Aleksey Kuznetsov
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -174,7 +171,11 @@
 //!
 //! ## License
 //!
-//! MIT
+//! MIT. See the LICENSE file for details.
+//!
+//! ## Authors
+//!
+//! See Cargo.toml for the full list of authors.
 
 extern crate syntax;
 extern crate rustc_plugin;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,7 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Urban Hafner, Vladimir Pouzanov,
-//                Mark Schifflin, Utkarsh Kukreti
-// Copyright 2016 Taylor Cramer, Alex Diez, Urban Hafner, Seb Glazebrook
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,3 +1,23 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Urban Hafner, Vladimir Pouzanov,
+//                Mark Schifflin, Utkarsh Kukreti
+// Copyright 2016 Taylor Cramer, Alex Diez, Urban Hafner, Seb Glazebrook
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 use syntax::{ast, codemap};
 use syntax::ext::base;
 use syntax::parse::token;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 use syntax::{ast, codemap};
 use syntax::ext::base;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Utkarsh Kukreti
-// Copyright 2016 Taylor Cramer, Alex Diez
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 use syntax::ptr::P;
 use syntax::ast;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Utkarsh Kukreti
+// Copyright 2016 Taylor Cramer, Alex Diez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 use syntax::ptr::P;
 use syntax::ast;
 use syntax::parse::token;

--- a/tests/alternates.rs
+++ b/tests/alternates.rs
@@ -1,19 +1,8 @@
-// Copyright 2015-2016 The Stainless Developers
+// Copyright 2015-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/alternates.rs
+++ b/tests/alternates.rs
@@ -1,5 +1,4 @@
-// Copyright 2015 Jonathan Reem
-// Copyright 2016 Urban Hafner
+// Copyright 2015-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/alternates.rs
+++ b/tests/alternates.rs
@@ -1,3 +1,21 @@
+// Copyright 2015 Jonathan Reem
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,19 +1,8 @@
-// Copyright 2016 The Stainless Developers
+// Copyright 2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,3 +1,20 @@
+// Copyright 2016 Taylor Cramer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Taylor Cramer
+// Copyright 2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner, Taylor Cramer
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/failing.rs
+++ b/tests/failing.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner, Taylor Cramer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/ignore.rs
+++ b/tests/ignore.rs
@@ -1,19 +1,8 @@
-// Copyright 2016 The Stainless Developers
+// Copyright 2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/ignore.rs
+++ b/tests/ignore.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 Urban Hafner, Alex Diez
+// Copyright 2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/ignore.rs
+++ b/tests/ignore.rs
@@ -1,3 +1,20 @@
+// Copyright 2016 Urban Hafner, Alex Diez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/nested_hooks.rs
+++ b/tests/nested_hooks.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Utkarsh Kukreti
-// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/nested_hooks.rs
+++ b/tests/nested_hooks.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Utkarsh Kukreti
+// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/nested_hooks.rs
+++ b/tests/nested_hooks.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,6 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,3 +1,22 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Aleksey Kuznetsov, Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,3 +1,23 @@
+// Copyright 2014 Jonathan Reem
+// Copyright 2015 Jonathan Reem, Vladimir Pouzanov, Aleksey Kuznetsov,
+//                Utkarsh Kukreti
+// Copyright 2016 Urban Hafner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #![feature(plugin)]
 #![plugin(stainless)]
 

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,19 +1,8 @@
-// Copyright 2014-2016 The Stainless Developers
+// Copyright 2014-2016 The Stainless Developers. See the LICENSE file at the top-level directory of
+// this distrubution.
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-// associated documentation files (the "Software"), to deal in the Software without restriction,
-// including without limitation the rights to use, copy, modify, merge, publish, distribute,
-// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all copies or
-// substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-// NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the MIT license. This file may not be copied, modified, or distributed except
+// according to those terms.
 
 #![feature(plugin)]
 #![plugin(stainless)]

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,7 +1,4 @@
-// Copyright 2014 Jonathan Reem
-// Copyright 2015 Jonathan Reem, Vladimir Pouzanov, Aleksey Kuznetsov,
-//                Utkarsh Kukreti
-// Copyright 2016 Urban Hafner
+// Copyright 2014-2016 The Stainless Developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,


### PR DESCRIPTION
I went through the whole commit history and added everyone who contributed even a single line to the license headers. Everyone is now also in the cargo file. The ordering of the names in the headers is somewhat random, I just added the name whenever I found it. That is apart from @reem. :) He's first whenever he contributed in a given name. And in the cargo file the names are sorted alphabetically. Again apart from Jonathan.