### PR TITLE
Added additional information for libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ That file is normally called `src/main.rs` for executables and
 ```
 
 This will make stainless available when you run the tests using `cargo
-test`.
+test`. 
+When using stainless only with a library, make sure to run tests using
+`cargo test --lib`.
 
 ## Overview
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 //!
 //! This will make stainless available when you run the tests using `cargo
 //! test`.
+//! When using stainless only with a library, make sure to run tests using
+//! `cargo test --lib`.
 //!
 //! ## Overview
 //!


### PR DESCRIPTION
When testing a library, it seem to be necessary to add the `--lib` flag to cargo for complication to even succeed.
When using the example provided in the README.md file, in `src/main.rs`, no problems arise, but renaming the same file to `src/lib.rs` render the rustc unable to compile the library for testing, both versions using `cargo test`. Adding the `--lib` flag fixes this problem for libraries.
I assume this is not necessarily your fault, but it is worth providing users with the information.