### PR TITLE
Fix build in latest nightly Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
   "Jonathan Reem <jonathan.reem@gmail.com>",
   "Aleksey Kuznetsov <zummenix@gmail.com>",
   "Alex Diez <alexvic.amatory@gmail.com>",
+  "Julien Wajsberg <julien@mozilla.com>",
   "Mark Schifflin <rschifflin@hotmail.com>",
   "Seb Glazebrook <sebastian.glazebrook@redbubble.com>",
   "Taylor Cramer <cramertj@cs.washington.edu>",

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -28,7 +28,7 @@
 /// modules respectively.
 ///
 
-use syntax::{ast, codemap, parse};
+use syntax::{ast, codemap, parse, tokenstream};
 use syntax::ptr::P;
 use syntax::ext::base;
 use syntax::util::small_vector::SmallVector;
@@ -63,7 +63,7 @@ pub enum SubBlock {
 /// that they are detected and expanded inside of the implementation
 /// of `describe!`.
 pub fn describe<'a>(cx: &'a mut base::ExtCtxt, sp: codemap::Span,
-                name: ast::Ident, tokens: Vec<ast::TokenTree>) -> Box<base::MacResult + 'a> {
+                name: ast::Ident, tokens: Vec<tokenstream::TokenTree>) -> Box<base::MacResult + 'a> {
     // Parse a full DescribeState from the input, emitting errors if used incorrectly.
     let state: DescribeState = Parse::parse(&mut parse::tts_to_parser(cx.parse_sess(), tokens, cx.cfg()), (sp, &mut*cx, Some(name)));
 


### PR DESCRIPTION
* TokenTree has moved to a new module tokenstream
* Blocks do not have `expr` properties anymore