### PR TITLE
Add more friendly error messages (WIP)

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,14 +26,23 @@ impl Parse<TestConfig> for Test {
         // Description of this test.
         let (description, _) = parser.parse_str().ok().expect("Test should have description");
 
-        Test {
-            // Get as a String
-            description: description.to_string(),
+        match parser.parse_block() {
+            Ok(block) => {
+                return Test {
+                    // Get as a String
+                    description: description.to_string(),
 
-            // The associated block
-            block: parser.parse_block().ok().unwrap(),
+                    // The associated block
+                    block: block,
 
-            test_config: test_config
+                    test_config: test_config
+                }
+            },
+            Err(mut err) => {
+                err.children.clear();
+                err.emit();
+                panic!("See above error");
+            }
         }
     }
 }

--- a/tests/my_test.rs
+++ b/tests/my_test.rs
@@ -1,0 +1,8 @@
+#![feature(plugin,const_fn)]
+#![plugin(stainless)]
+
+describe! a_panic {
+   it "fails to parse" () {
+       assert!(true);
+   }
+}


### PR DESCRIPTION
So I learned a bit playing with this crate seeing if I could fix issue #49.

Here's what I got <img width="935" alt="screen shot 2017-02-18 at 1 00 16 am" src="https://cloud.githubusercontent.com/assets/4073509/23091942/b2d45ffc-f575-11e6-9b51-e2c379afee88.png">

This PR right now just demonstrates a nicer way to surface the error in one place. I can apply this same way of surfacing the error across the rest of the crate where we currently have panics.

The reason it is still panicing is because `Parse::parse()` still requires a return value of self, and since parse_block failed to return an `syntax::ast::Block`, I don't have a value to use for `Test::block`.

@reem I was hoping to get your opinion on what your preferred way to apply this change would be. This is my first time working with syntax extensions and I don't have much experience writing syntax parsers in general.

Options I see (but there certainly could be some I'm overlooking):

* Make `Test::block` an option type, make it none when `parse_block()` fails. Although I'm not sure how Generate::generate should behave when block is `None`
* Still panic anytime a parse fails, but add this friendlier way of displaying the error beforehand. This is really ugly and hacky but easiest to implement and still gives the user the info they need to locate the issue.
* Make Parse::parse return an Option<Self>. Not really sure about the implications of this one. Again, parsing and syntax extensions is really not my area of expertise.

I think I can implement any of the 3 myself, but would definitely appreciate a bit of insight beforehand.