### PR TITLE
make example compilable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ That file is normally called `src/main.rs` for executables and
 ```
 
 This will make stainless available when you run the tests using `cargo
-test`. 
+test`.
 When using stainless only with a library, make sure to run tests using
 `cargo test --lib`.
 
@@ -146,7 +146,8 @@ mod tests {
 
     describe! stainless {
         it "can use HashMap" {
-            let map = HashMap::new();
+            let mut map = HashMap::new();
+            map.insert("key", "value");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,8 @@
 //!
 //!     describe! stainless {
 //!         it "can use HashMap" {
-//!             let map = HashMap::new();
+//!             let mut map = HashMap::new();
+//!             map.insert("key", "value");
 //!         }
 //!     }
 //! }


### PR DESCRIPTION
eliminate: cannot infer type for `K`